### PR TITLE
Fix graph x-axis for timestamp

### DIFF
--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -51,7 +51,7 @@ class Graph extends Component<IProps, {}> {
             elem.load(this.table);
             elem.setAttribute("view", "y_line");
             elem.setAttribute("column-pivots", '["stock"]');
-            elem.setAttribute("row_pivots", '["timestamp"]');
+            elem.setAttribute("row-pivots", '["timestamp"]');
             elem.setAttribute("columns", '["top_ask_price"]');
             elem.setAttribute("aggregates",
                 '{"stock":"distinct_count", "top_ask_price":"avg", "top_bid_price":"avg", "timestamp":"distinct_count"}'


### PR DESCRIPTION
Description:
- This pull request addresses an issue where the x-axis on the graph was displaying timestamps incorrectly. The problem was observed after clicking on button "Start Streaming Data".

Screenshots:
- Before PR
<img width="845" alt="beforePR" src="https://github.com/theforage/forage-jpmc-swe-task-2/assets/66007323/1bd8dcb5-a475-466e-bada-65024535db35">
- After PR
<img width="908" alt="afterPR" src="https://github.com/theforage/forage-jpmc-swe-task-2/assets/66007323/d545f3db-509c-44b2-baae-f68c4bceebca">
