### PR TITLE
Update App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import './App.css';
  */
 interface IState {
   data: ServerRespond[],
+  showGraph : boolean,
 }
 
 /**
@@ -22,6 +23,7 @@ class App extends Component<{}, IState> {
       // data saves the server responds.
       // We use this state to parse data down to the child element (Graph) as element property
       data: [],
+      showGraph : false,
     };
   }
 
@@ -29,13 +31,30 @@ class App extends Component<{}, IState> {
    * Render Graph react component with state.data parse as property data
    */
   renderGraph() {
-    return (<Graph data={this.state.data}/>)
+    if(this.state.showGraph)
+    {
+      return (<Graph data={this.state.data}/>)
+    }
+    
   }
 
   /**
    * Get new data from server and update the state with the new data
    */
   getDataFromServer() {
+    let x=0
+    const interval = setInterval(() =>{ DataStreamer.getData((serverResponds :ServerRespond[]) =>{ 
+        this.setState({
+          data : serverResponds,
+          showGraph :true
+      });
+    });
+     x++;
+       if(x>1000)
+       {
+        clearInterval(interval);
+       }
+  },100)
     DataStreamer.getData((serverResponds: ServerRespond[]) => {
       // Update the state by creating a new array of data that consists of
       // Previous data in the state and the new data from server


### PR DESCRIPTION

I didn't use distinct count on timestamp because you’re essentially counting how many distinct timestamps appear, which isn't typically useful for visualizing time-series data. Since the timestamp field is being used as a row-pivot, it's already grouping data by each distinct timestamp without needing to aggregate it. You'd want the graph to display the actual time points rather than a count of those time points.

However, if you need to use "timestamp": "distinct count" for a specific purpose (such as counting the number of unique timestamps or events), feel free to include it, but it may not provide meaningful insights in a line chart that shows trends over time.